### PR TITLE
New functions and memleak fix

### DIFF
--- a/doc/xml_tree.txt
+++ b/doc/xml_tree.txt
@@ -116,7 +116,7 @@
 // xmlNodeGetSpacePreserve
 // xmlNodeIsText
 // xmlNodeListGetRawString
-// xmlNodeListGetString
+// * xmlNodeListGetString
 // xmlNodeSetBase
 // * xmlNodeSetContent
 // xmlNodeSetContentLen

--- a/xml_parser.go
+++ b/xml_parser.go
@@ -171,6 +171,13 @@ func (p *Parser) Parse() int {
 	return int(C.xmlParseDocument(p.Ptr))
 }
 
+func (p *Parser) MyDoc() *Document {
+	if docptr := p.Ptr.myDoc; docptr != nil {
+		return makeDoc(docptr)
+	}
+	return nil
+}
+
 // xmlParseEntity
 func ParseEntity(filename string) *Document {
 	ptr := C.CString(filename)

--- a/xml_tree.go
+++ b/xml_tree.go
@@ -537,6 +537,19 @@ func (node *Node) GetContent() string {
 	return C.GoString(content)
 }
 
+// xmlNodeListGetString
+func (node *Node) ListGetString(inLine bool) string {
+	ptr := node.Ptr
+	docptr := C.xmlDocPtr((*C.xmlDoc)(ptr.doc))
+	cInLine := C.int(0)
+	if inLine {
+		cInLine = C.int(1)
+	}
+	str := C.to_charptr(C.xmlNodeListGetString(docptr, ptr, cInLine))
+	defer C.free_string(str)
+	return C.GoString(str)
+}
+
 // xmlNodeSetContent
 func (node *Node) SetContent(content string) {
 	ptr := C.CString(content)

--- a/xml_tree.go
+++ b/xml_tree.go
@@ -532,7 +532,9 @@ func (doc *Document) NodeDump(buf *Buffer, cur *Node, level int, format int) int
 
 // xmlNodeGetContent
 func (node *Node) GetContent() string {
-	return C.GoString(C.to_charptr(C.xmlNodeGetContent(node.Ptr)))
+	content := C.to_charptr(C.xmlNodeGetContent(node.Ptr))
+	defer C.free_string(content)
+	return C.GoString(content)
 }
 
 // xmlNodeSetContent


### PR DESCRIPTION
- This adds an accessor for `xmlParserCtxt->myDoc`; usecase:
  
  ```
  parser := golibxml.CreateDocParser("...")
  parser.Parse()
  doc := parser.MyDoc()
  ```
- Fixes a mem leak in `Node.GetContent()`
- Adds a wrapper for `xmlNodeListGetString()`: `Node.ListGetString()`
